### PR TITLE
Add advanced feature selection choices

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,6 @@ matplotlib>=3.7.0
 seaborn>=0.12.0
 
 # Additional utilities
-pathlib2>=2.3.7; python_version < '3.4' 
+pathlib2>=2.3.7; python_version < '3.4'
+pyHSICLasso>=1.4.2
+


### PR DESCRIPTION
## Summary
- add HSICLasso-based feature selector with fallback
- allow selecting MI, HSIC, f-regression or RFECV in `battle_tested_optuna_playbook.py`
- include pyHSICLasso in requirements

## Testing
- `python -m py_compile battle_tested_optuna_playbook.py`
- `python -m py_compile auto_optuna-V1.py auto_optuna-V1.1.py auto_optuna-V1.2.py auto_optuna-V1.3.py test_best_model.py`


------
https://chatgpt.com/codex/tasks/task_b_684dedc40cfc8330b33f51c170650ee8