### PR TITLE
Tuneable prune threshold

### DIFF
--- a/battle_tested_optuna_playbook.py
+++ b/battle_tested_optuna_playbook.py
@@ -264,17 +264,27 @@ class BattleTestedOptimizer:
             pipe = Pipeline(steps)
             
             # Cross-validation scoring
-            scores = cross_val_score(pipe, self.X_clean, self.y, cv=self.cv, scoring='r2', n_jobs=12)
+            scores = cross_val_score(
+                pipe,
+                self.X_clean,
+                self.y,
+                cv=self.cv,
+                scoring="r2",
+                n_jobs=12,
+            )
             scores = scores[np.isfinite(scores)]  # Remove any inf/nan values
-            
+
             if len(scores) == 0:
                 raise optuna.exceptions.TrialPruned()
-                
+
             mean_score = np.mean(scores)
             std_score = np.std(scores)
-            
+
+            # Tunable prune threshold
+            prune_floor = trial.suggest_float("prune_floor", -3.0, -0.5)
+
             # Early failure safety net
-            if mean_score < -2.0:  # Model performing much worse than predicting mean
+            if mean_score < prune_floor:  # Model performing much worse than predicting mean
                 raise optuna.exceptions.TrialPruned()
             
             # Store additional metrics and pipeline


### PR DESCRIPTION
## Summary
- make the early pruning floor an Optuna parameter

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `echo 1 | pytest test_best_model.py::test_saved_model -q -s` *(fails: FileNotFoundError: preprocessing_pipeline.pkl)*

------
https://chatgpt.com/codex/tasks/task_b_684dee0b0a24833098a1151061e70b40