### PR TITLE
Document auto_optuna versions

### DIFF
--- a/auto_optuna-V1.1.py
+++ b/auto_optuna-V1.1.py
@@ -5,6 +5,11 @@ Battle-Tested End-to-End ML Playbook v1.1 - FAST PHASE 1 EDITION
 Phase 1: FAST model selection (1 trial per model, 10 min max each)
 Phase 2: DEEP data optimization using ONLY the winning model
 - 12 threads, 1 iteration, immediate winner selection
+
+This script introduced the two-phase optimisation strategy. For a
+complete history of the different versions see
+`docs/optuna_scripts_overview.md`.
+Use `auto_optuna-V1.3.py` for the latest functionality.
 """
 
 # =============================================================================

--- a/auto_optuna-V1.2.py
+++ b/auto_optuna-V1.2.py
@@ -5,6 +5,9 @@ Battle-Tested End-to-End ML Playbook v1.2 - SYSTEMATIC 3-PHASE EDITION
 Phase 1: MODEL FAMILY TOURNAMENT (Raw Data) - Find best model family
 Phase 2: ITERATIVE PREPROCESSING STACK OPTIMIZATION - Add 1 method at a time  
 Phase 3: DEEP MODEL HYPERPARAMETER OPTIMIZATION - Reach noise ceiling
+
+This version became the foundation for the v1.3 release. Refer to
+`docs/optuna_scripts_overview.md` for how each script fits together.
 """
 
 # =============================================================================

--- a/auto_optuna-V1.3.py
+++ b/auto_optuna-V1.3.py
@@ -13,6 +13,10 @@ Implementation strategy:
   behaviours that changed.  
 • Maintain 100 % interface compatibility so existing downstream code keeps
   working unchanged.
+
+This is the current recommended entry point for new experiments. Older
+versions remain available for reproducibility. A concise overview of all
+scripts can be found in `docs/optuna_scripts_overview.md`.
 """
 
 from __future__ import annotations

--- a/auto_optuna-V1.py
+++ b/auto_optuna-V1.py
@@ -8,6 +8,10 @@ Pushes theoretical accuracy limits on datasets using:
 - Cross-validation with multiple model types
 - Strategic Optuna optimization until target R² achieved
 - Statistical significance testing with bootstrap
+
+This is the original version of the auto-optuna workflow. Later revisions add
+extra phases and configuration options. See `docs/optuna_scripts_overview.md`
+for a full comparison of available scripts.
 """
 
 # =============================================================================

--- a/battle_tested_optuna_playbook.py
+++ b/battle_tested_optuna_playbook.py
@@ -7,6 +7,10 @@ Pushes theoretical accuracy limits on datasets using:
 - Robust preprocessing pipeline
 - Cross-validation with multiple model types
 - Strategic Optuna optimization until target R² achieved
+
+This legacy file predates the `auto_optuna` series of scripts. It is kept
+for historical reference only. See `docs/optuna_scripts_overview.md` for the
+recommended modern equivalents.
 """
 
 # =============================================================================

--- a/docs/optuna_scripts_overview.md
+++ b/docs/optuna_scripts_overview.md
@@ -1,0 +1,13 @@
+# Optuna Script Versions
+
+This project contains several iterations of the `auto_optuna` script plus a legacy playbook. The table below summarizes their purpose and evolution.
+
+| Script | Description |
+| ------ | ----------- |
+| `battle_tested_optuna_playbook.py` | Original proof-of-concept pipeline combining preprocessing, model selection and Optuna hyperparameter tuning. Superseded by later versions. |
+| `auto_optuna-V1.py` | First major refactor of the playbook with improved dataset handling and more flexible preprocessing. |
+| `auto_optuna-V1.1.py` | Adds a two-phase optimization (fast model selection followed by deep tuning). Useful when quick winner identification is needed. |
+| `auto_optuna-V1.2.py` | Introduces a systematic three-phase approach: model family tournament, preprocessing stack search and deep hyperparameter optimization. Serves as the baseline for v1.3. |
+| `auto_optuna-V1.3.py` | Current recommended version. Extends v1.2 with a centralized config dictionary and modular callbacks. It imports and extends v1.2 under the hood to avoid code duplication. |
+
+For new experiments, start with **`auto_optuna-V1.3.py`**. Earlier versions are kept for reference and for reproducing older results.


### PR DESCRIPTION
## Summary
- add `optuna_scripts_overview.md` to explain the purpose of each optuna script
- note the new overview in every auto-optuna file
- mark the legacy playbook as historical only

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: reading from stdin while output is captured)*

------
https://chatgpt.com/codex/tasks/task_b_684e18bbd9108330ba83a55f52f8bf80