### PR TITLE
Add CNN workflow trigger flag

### DIFF
--- a/auto_optuna-V1.1.py
+++ b/auto_optuna-V1.1.py
@@ -292,6 +292,7 @@ class BattleTestedOptimizer:
         self.preprocessing_pipeline = None
         self.iteration_count = 0
         self.ceiling_history = []
+        self.need_cnn = False
         
         # NEW: Two-phase optimization attributes
         self.validator_model_class = None
@@ -1363,6 +1364,10 @@ class BattleTestedOptimizer:
         # Success criteria
         beats_validation = r2_test > self.validation_r2
         near_ceiling = abs(r2_test - self.noise_ceiling) < 0.05
+
+        # Determine if CNN workflow should be triggered
+        self.need_cnn = r2_test < (self.noise_ceiling - 0.05)
+        self.logger.info("Need CNN workflow: %s", self.need_cnn)
         
         self.logger.info("Model Assessment:")
         self.logger.info("  Beats RidgeCV validation: %s", "✅ YES" if beats_validation else "❌ NO")
@@ -1383,6 +1388,7 @@ class BattleTestedOptimizer:
             'noise_ceiling': self.noise_ceiling,
             'beats_validation': beats_validation,
             'near_ceiling': near_ceiling,
+            'need_cnn': self.need_cnn,
             'best_model_type': self.study.best_trial.user_attrs['model_type'],
             'best_params': self.study.best_params,
             'ceiling_history': self.ceiling_history,
@@ -1650,6 +1656,9 @@ def main():
             else:
                 print(f"\n{Colors.YELLOW}{Colors.BOLD}⚠️  Target not reached: {final_results['test_r2']:.4f} < {optimizer.target_r2:.4f}{Colors.END}")
                 set_console_title("⚠️ Target not reached")
+
+            if final_results.get('need_cnn'):
+                print(f"{Colors.YELLOW}⚠️ CNN workflow recommended{Colors.END}")
         
         print(f"\n📁 Outputs saved to: {Colors.BOLD}best_model_hold{DATASET}/{Colors.END}")
         

--- a/auto_optuna-V1.3.py
+++ b/auto_optuna-V1.3.py
@@ -237,7 +237,10 @@ def main():  # noqa: D401 – imperative entry-point
     X, y = _load_dataset(DATASET)
 
     optimizer = SystematicOptimizerV13(dataset_num=DATASET)
-    return optimizer.run_systematic_optimization(X, y)
+    results = optimizer.run_systematic_optimization(X, y)
+    if results and results.get('need_cnn'):
+        print("⚠️ CNN workflow recommended")
+    return results
 
 
 if __name__ == "__main__":

--- a/battle_tested_optuna_playbook.py
+++ b/battle_tested_optuna_playbook.py
@@ -157,6 +157,7 @@ class BattleTestedOptimizer:
         self.preprocessing_pipeline = None
         self.use_iforest = use_iforest
         self.use_lof = use_lof
+        self.need_cnn = False
         
         # Setup logging
         self.setup_logging()
@@ -525,6 +526,10 @@ class BattleTestedOptimizer:
         # Success criteria
         beats_baseline = r2_test > self.baseline_r2
         near_ceiling = abs(r2_test - self.noise_ceiling) < 0.05
+
+        # Determine if CNN workflow should be triggered
+        self.need_cnn = r2_test < (self.noise_ceiling - 0.05)
+        self.logger.info("Need CNN workflow: %s", self.need_cnn)
         
         self.logger.info("Model Assessment:")
         self.logger.info(f"  Beats baseline: {'✅ YES' if beats_baseline else '❌ NO'}")
@@ -544,6 +549,7 @@ class BattleTestedOptimizer:
             'noise_ceiling': self.noise_ceiling,
             'beats_baseline': beats_baseline,
             'near_ceiling': near_ceiling,
+            'need_cnn': self.need_cnn,
             'best_model_type': self.study.best_trial.user_attrs['model_type'],
             'best_params': self.study.best_params
         }
@@ -713,6 +719,8 @@ def main():
         if results:
             print(f"🧪 Test set R²: {results['test_r2']:.4f}")
             print(f"🏗️ Best model: {results['best_model_type']}")
+            if results.get('need_cnn'):
+                print(f"{Colors.YELLOW}⚠️ CNN workflow recommended{Colors.END}")
         
         print(f"\n📁 All outputs saved to: {Colors.BOLD}best_model_hold{DATASET}/{Colors.END}")
         print(f"   - hold{DATASET}_best_model.pkl (trained model)")


### PR DESCRIPTION
## Summary
- flag `need_cnn` indicates when a CNN model should be triggered
- set and log this flag after final evaluation in optimizer classes
- propagate flag in output dictionaries and print warnings in main scripts

## Testing
- `python -m py_compile auto_optuna-V1.py auto_optuna-V1.1.py auto_optuna-V1.2.py auto_optuna-V1.3.py battle_tested_optuna_playbook.py test_best_model.py`

------
https://chatgpt.com/codex/tasks/task_b_684e1894830883308c7e50e90d2e94c6