### PR TITLE
Handle std_score initialization failure

### DIFF
--- a/auto_optuna-V1.1.py
+++ b/auto_optuna-V1.1.py
@@ -843,6 +843,7 @@ class BattleTestedOptimizer:
             ('ridge', RidgeCV(alphas=np.logspace(-3, 3, 20)))
         ])
         
+        std_score = 0.0
         try:
             scores = cross_val_score(validation_pipe, self.X, self.y, cv=self.cv, scoring='r2', n_jobs=11)
             scores = scores[np.isfinite(scores)]  # Remove any inf/nan values
@@ -862,12 +863,14 @@ class BattleTestedOptimizer:
             else:
                 self.noise_ceiling = 0.95  # Default reasonable ceiling
                 self.validation_r2 = 0.0
-                
+                # std_score remains 0.0
+
         except Exception as e:
             self.logger.error("Noise ceiling estimation failed: %s", e)
             self.noise_ceiling = 0.95  # Default fallback
             self.validation_r2 = 0.0
-        
+            # retain std_score from any partial computation or default 0.0
+
         self.logger.info("RidgeCV validation R²: %.4f ± %.4f", self.validation_r2, std_score)
         self.logger.info("Noise ceiling (mean + 2·std): %.4f", self.noise_ceiling)
         

--- a/auto_optuna-V1.py
+++ b/auto_optuna-V1.py
@@ -647,6 +647,7 @@ class BattleTestedOptimizer:
             ('ridge', RidgeCV(alphas=np.logspace(-3, 3, 20)))
         ])
         
+        std_score = 0.0
         try:
             scores = cross_val_score(validation_pipe, self.X, self.y, cv=self.cv, scoring='r2', n_jobs=11)
             scores = scores[np.isfinite(scores)]  # Remove any inf/nan values
@@ -666,12 +667,14 @@ class BattleTestedOptimizer:
             else:
                 self.noise_ceiling = 0.95  # Default reasonable ceiling
                 self.validation_r2 = 0.0
-                
+                # std_score remains 0.0
+
         except Exception as e:
             self.logger.error("Noise ceiling estimation failed: %s", e)
             self.noise_ceiling = 0.95  # Default fallback
             self.validation_r2 = 0.0
-        
+            # retain std_score from any partial computation or default 0.0
+
         self.logger.info("RidgeCV validation R²: %.4f ± %.4f", self.validation_r2, std_score)
         self.logger.info("Noise ceiling (mean + 2·std): %.4f", self.noise_ceiling)
         

--- a/battle_tested_optuna_playbook.py
+++ b/battle_tested_optuna_playbook.py
@@ -221,8 +221,11 @@ class BattleTestedOptimizer:
             ('ridge', RidgeCV(alphas=np.logspace(-3, 3, 20)))
         ])
         
+        std_score = 0.0
         try:
-            scores = cross_val_score(baseline_pipe, self.X, self.y, cv=self.cv, scoring='r2', n_jobs=12)
+            scores = cross_val_score(
+                baseline_pipe, self.X, self.y, cv=self.cv, scoring='r2', n_jobs=12
+            )
             scores = scores[np.isfinite(scores)]  # Remove any inf/nan values
             
             if len(scores) > 0:
@@ -234,11 +237,13 @@ class BattleTestedOptimizer:
             else:
                 self.noise_ceiling = 0.95  # Default reasonable ceiling
                 self.baseline_r2 = 0.0
+                # std_score remains 0.0
                 
         except Exception as e:
             self.logger.error(f"Noise ceiling estimation failed: {e}")
             self.noise_ceiling = 0.95  # Default fallback
             self.baseline_r2 = 0.0
+            # retain std_score from any partial computation or default 0.0
         
         self.logger.info(f"Baseline Ridge R²: {self.baseline_r2:.4f} ± {std_score:.4f}")
         self.logger.info(f"Noise ceiling (mean + 2·std): {self.noise_ceiling:.4f}")


### PR DESCRIPTION
## Summary
- prevent `std_score` from being undefined when ridge scoring fails
- keep last `std_score` in failure paths

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: pytest cannot read input from `test_best_model.py`)*

------
https://chatgpt.com/codex/tasks/task_b_684e189434848330ace7bb45333f75c7