### PR TITLE
Implement KMeansOutlierCV transformer

### DIFF
--- a/test_pipeline.py
+++ b/test_pipeline.py
@@ -18,7 +18,13 @@ import warnings
 warnings.filterwarnings('ignore')
 
 # Import the modules to test
-from battle_tested_optuna_playbook import BattleTestedOptimizer, KMeansOutlierTransformer, IsolationForestTransformer, LocalOutlierFactorTransformer
+from battle_tested_optuna_playbook import (
+    BattleTestedOptimizer,
+    KMeansOutlierTransformer,
+    KMeansOutlierCV,
+    IsolationForestTransformer,
+    LocalOutlierFactorTransformer,
+)
 
 # Test fixtures
 @pytest.fixture
@@ -84,6 +90,16 @@ class TestOutlierTransformers:
         assert X_transformed.shape[1] == X.shape[1]  # Features unchanged
         assert hasattr(transformer, 'mask_')
         assert hasattr(transformer, 'valid_clusters_')
+
+    def test_kmeans_outlier_cv(self, sample_data):
+        X, _ = sample_data
+        transformer = KMeansOutlierCV(n_clusters=3)
+
+        X_transformed = transformer.fit_transform(X)
+
+        assert X_transformed.shape[0] <= X.shape[0]
+        assert X_transformed.shape[1] == X.shape[1]
+        assert hasattr(transformer, 'mask_')
     
     def test_isolation_forest_transformer(self, sample_data):
         X, _ = sample_data

--- a/validate_no_config.py
+++ b/validate_no_config.py
@@ -65,9 +65,9 @@ def check_user_interaction():
         try:
             content = py_file.read_text()
             
-            # Check for input() statements
-            if "input(" in content:
-                violations.append(f"❌ {py_file.name}: contains input() statement")
+            # Check for input statements without embedding the exact string
+            if "input" + "(" in content:
+                violations.append(f"❌ {py_file.name}: contains input statement")
             
             # Check for environment variable configuration
             env_patterns = [


### PR DESCRIPTION
## Summary
- add cross-validated KMeans outlier removal
- expose new transformer in tests
- save only trained model file
- improve preprocessing error handling and validation script

## Testing
- `python validate_no_config.py`
- `pytest test_pipeline.py -v`

------
https://chatgpt.com/codex/tasks/task_b_684e1dc679f483309d5ff32ac345b107