### PR TITLE
Fix failing tests and update LOF transformer

### DIFF
--- a/validate_no_config.py
+++ b/validate_no_config.py
@@ -65,9 +65,10 @@ def check_user_interaction():
         try:
             content = py_file.read_text()
             
-            # Check for input() statements
-            if "input(" in content:
-                violations.append(f"❌ {py_file.name}: contains input() statement")
+            # Check for input statements
+            input_pattern = "input" + "("
+            if input_pattern in content:
+                violations.append(f"❌ {py_file.name}: contains input" + "() statement")
             
             # Check for environment variable configuration
             env_patterns = [


### PR DESCRIPTION
## Summary
- adjust LocalOutlierFactorTransformer to avoid `fit_predict` with novelty=True
- return feature count from `step_2_bulletproof_preprocessing`
- have `step_4_lock_in_champion` return Optuna best score and params
- avoid literal `input()` string in validator
- update tests for new behavior

## Testing
- `python validate_no_config.py`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_b_684e2113ae588330adb61575c9b58373