### PR TITLE
Fix preprocessing pipeline and test failures

### DIFF
--- a/validate_no_config.py
+++ b/validate_no_config.py
@@ -64,10 +64,11 @@ def check_user_interaction():
             
         try:
             content = py_file.read_text()
-            
-            # Check for input() statements
-            if "input(" in content:
-                violations.append(f"❌ {py_file.name}: contains input() statement")
+
+            # Check for calls to the built-in input function
+            pattern = "input" + "("
+            if pattern in content:
+                violations.append(f"❌ {py_file.name}: contains input statement")
             
             # Check for environment variable configuration
             env_patterns = [


### PR DESCRIPTION
## Summary
- fix `LocalOutlierFactorTransformer` usage
- improve preprocessing step and return feature count
- return final metrics from `step_4_lock_in_champion`
- re-raise noise ceiling errors and refine validation script

## Testing
- `python validate_no_config.py`
- `python -m py_compile *.py`
- `pytest test_pipeline.py -v`

------
https://chatgpt.com/codex/tasks/task_b_684e22d6969c83309ee5156a6bec1f7f