### PR TITLE
Add pylint check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,11 @@ jobs:
         mypy --ignore-missing-imports *.py || echo "Type checking issues found (non-blocking)"
       continue-on-error: true
 
+    - name: Lint with Pylint (score > 9 required)
+      run: |
+        pip install pylint
+        pylint $(git ls-files '*.py') --fail-under=9
+
   security:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- run pylint in CI and fail if score < 9

## Testing
- `python validate_no_config.py`
- `pytest test_pipeline.py -v` *(fails: ModuleNotFoundError: No module named 'battle_tested_optuna_playbook')*
- `python -m py_compile *.py`
- `pylint $(git ls-files '*.py') --fail-under=9` *(fails: score 4.84/10)*

------
https://chatgpt.com/codex/tasks/task_b_684e2dd3365883309c242e02959b9c36