### PR TITLE
Add pylint configuration

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,8 @@
+[MASTER]
+ignore=tests
+
+[MESSAGES CONTROL]
+disable=missing-module-docstring,missing-function-docstring,missing-class-docstring
+
+[FORMAT]
+max-line-length=100


### PR DESCRIPTION
## Summary
- add a basic `.pylintrc` for project pylint settings

## Testing
- `python validate_no_config.py` *(fails: Could not import battle_tested_optuna_playbook)*
- `pytest test_pipeline.py -v` *(fails: ModuleNotFoundError: No module named 'battle_tested_optuna_playbook')*
- `python -m py_compile $(ls *.py)`

------
https://chatgpt.com/codex/tasks/task_b_684e2dd758f48330b03d845493ef33c3