### PR TITLE
Improve pylint configuration

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,11 @@
+[MASTER]
+ignore=tests
+
+[FORMAT]
+max-line-length=127
+
+[MESSAGES CONTROL]
+disable=missing-module-docstring
+
+[TYPECHECK]
+ignore-missing-imports=yes


### PR DESCRIPTION
## Summary
- refine `.pylintrc` with repository style rules

## Testing
- `python validate_no_config.py` *(fails: Could not import battle_tested_optuna_playbook)*
- `pytest test_pipeline.py -v` *(fails: ModuleNotFoundError: No module named 'battle_tested_optuna_playbook')*
- `python -m py_compile $(ls *.py)`

------
https://chatgpt.com/codex/tasks/task_b_684e2dd758f48330b03d845493ef33c3