### PR TITLE
Add pylint check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,11 @@ jobs:
         mypy --ignore-missing-imports *.py || echo "Type checking issues found (non-blocking)"
       continue-on-error: true
 
+    - name: Lint with Pylint (score > 9 required)
+      run: |
+        pip install pylint
+        pylint $(git ls-files '*.py') --fail-under=9
+
   security:
     runs-on: ubuntu-latest
     steps:

--- a/battle_tested_optuna_playbook.py
+++ b/battle_tested_optuna_playbook.py
@@ -1,0 +1,17 @@
+"""Compatibility wrapper for the refactored auto_optuna package."""
+from pathlib import Path
+
+from auto_optuna import (
+    BattleTestedOptimizer,
+    KMeansOutlierTransformer,
+    IsolationForestTransformer,
+    LocalOutlierFactorTransformer,
+)
+
+DATASET = 1
+
+
+def main():
+    """Run Hold-1 optimization using the new package."""
+    from auto_optuna.main import run_hold1
+    return run_hold1()


### PR DESCRIPTION
## Summary
- run pylint in CI and fail if score < 9
- provide compatibility layer for new `auto_optuna` package

## Testing
- `python validate_no_config.py`
- `pytest test_pipeline.py -v` *(fails: AttributeError: 'BattleTestedOptimizer' object has no attribute 'step_1_pin_down_ceiling')*
- `python -m py_compile *.py`
- `pylint $(git ls-files '*.py') --fail-under=9` *(fails: score 3.81/10)*

------
https://chatgpt.com/codex/tasks/task_b_684e2dd3365883309c242e02959b9c36