### PR TITLE
Implement dataset mapping and tests

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -10,14 +10,25 @@ Main Components:
 - Utils: Utility functions
 """
 
-from .optimizer import SystematicOptimizer, BattleTestedOptimizer
-from .transformers import (
-    KMeansOutlierTransformer,
-    IsolationForestTransformer, 
-    LocalOutlierFactorTransformer
-)
-from .config import CONFIG, Colors
-from .utils import load_dataset, setup_logging, console, HAS_RICH, Tree
+if __package__ in (None, ""):
+    # Support running without installing as a package
+    from optimizer import SystematicOptimizer, BattleTestedOptimizer
+    from transformers import (
+        KMeansOutlierTransformer,
+        IsolationForestTransformer,
+        LocalOutlierFactorTransformer,
+    )
+    from config import CONFIG, Colors
+    from utils import load_dataset, setup_logging, console, HAS_RICH, Tree
+else:
+    from .optimizer import SystematicOptimizer, BattleTestedOptimizer
+    from .transformers import (
+        KMeansOutlierTransformer,
+        IsolationForestTransformer,
+        LocalOutlierFactorTransformer,
+    )
+    from .config import CONFIG, Colors
+    from .utils import load_dataset, setup_logging, console, HAS_RICH, Tree
 
 __version__ = "1.3.0"
 __all__ = [

--- a/config.py
+++ b/config.py
@@ -40,6 +40,13 @@ CONFIG = {
         "wine": {"loader": "load_wine", "type": "classification", "name": "Wine"},
         "breast_cancer": {"loader": "load_breast_cancer", "type": "classification", "name": "Breast Cancer Wisconsin"},
     },
+
+    # Mapping from integer IDs to dataset keys within SKLEARN_DATASETS
+    "DATASET_ID_MAP": {
+        1: "diabetes",
+        2: "california_housing",
+        3: "diabetes",  # Defaulting to diabetes for hold-3
+    },
     
     # Optuna optimization parameters
     "OPTUNA": {
@@ -111,4 +118,29 @@ CONFIG = {
         "MODEL_FILE_TEMPLATE": "hold{dataset_num}_final_model.pkl",
         "RESULTS_FILE_TEMPLATE": "hold{dataset_num}_results.txt"
     }
-} 
+}
+
+# Mapping of dataset IDs to friendly names and optional file paths. The
+# loaders are handled via the SKLEARN_DATASETS configuration above. File
+# paths are left as ``None`` for built-in datasets but the structure allows
+# external CSV files to be specified if needed.
+DATASET_FILES = {
+    1: {
+        "name": CONFIG["SKLEARN_DATASETS"]["diabetes"]["name"],
+        "dataset": "diabetes",
+        "predictors": None,
+        "targets": None,
+    },
+    2: {
+        "name": CONFIG["SKLEARN_DATASETS"]["california_housing"]["name"],
+        "dataset": "california_housing",
+        "predictors": None,
+        "targets": None,
+    },
+    3: {
+        "name": CONFIG["SKLEARN_DATASETS"]["diabetes"]["name"],
+        "dataset": "diabetes",
+        "predictors": None,
+        "targets": None,
+    },
+}

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ import argparse
 import sys
 from pathlib import Path
 
-from config import CONFIG, Colors
+from config import CONFIG, Colors, DATASET_FILES
 from utils import load_dataset, validate_dataset_files
 from optimizer import SystematicOptimizer, BattleTestedOptimizer
 
@@ -28,18 +28,27 @@ def main():
     
     args = parser.parse_args()
     
-    # Validate dataset files exist
-    if not validate_dataset_files(args.dataset):
-        print(f"{Colors.RED}❌ Dataset {args.dataset} files not found!{Colors.END}")
-        print(f"Expected files: {DATASET_FILES[args.dataset]['predictors']}, {DATASET_FILES[args.dataset]['targets']}")
+    dataset_key = CONFIG["DATASET_ID_MAP"].get(args.dataset)
+    if dataset_key is None:
+        print(f"{Colors.RED}❌ Invalid dataset ID: {args.dataset}{Colors.END}")
+        sys.exit(1)
+
+    # Validate dataset availability / files
+    if not validate_dataset_files(dataset_key):
+        print(f"{Colors.RED}❌ Dataset '{dataset_key}' files not found!{Colors.END}")
+        info = DATASET_FILES.get(args.dataset, {})
+        if info.get('predictors') or info.get('targets'):
+            print(
+                f"Expected files: {info.get('predictors')} | {info.get('targets')}"
+            )
         sys.exit(1)
     
     # Load dataset
     print(f"{Colors.BOLD}{Colors.CYAN}🚀 Starting Auto Optuna Optimization{Colors.END}")
     print(f"Dataset: {DATASET_FILES[args.dataset]['name']}")
     print(f"Optimizer: {args.optimizer}")
-    
-    X, y = load_dataset(args.dataset)
+
+    X, y = load_dataset(dataset_key)
     
     # Initialize optimizer
     if args.optimizer == 'systematic':

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import pytest
+
+ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, ROOT_DIR)
+
+from config import CONFIG, DATASET_FILES
+from utils import load_dataset, validate_dataset_files
+from optimizer import SystematicOptimizer, BattleTestedOptimizer
+
+@pytest.mark.parametrize("dataset_id", [1, 2, 3])
+def test_load_dataset(dataset_id):
+    dataset_key = CONFIG["DATASET_ID_MAP"][dataset_id]
+    assert validate_dataset_files(dataset_key)
+    X, y = load_dataset(dataset_key)
+    assert X.size > 0
+    assert y.size > 0
+
+
+def test_systematic_optimizer_single_trial():
+    dataset_key = CONFIG["DATASET_ID_MAP"][1]
+    X, y = load_dataset(dataset_key)
+    opt = SystematicOptimizer(dataset_num=1, max_hyperopt_trials=1)
+    results = opt.run_systematic_optimization(X, y)
+    assert "test_r2" in results
+
+
+def test_battle_tested_optimizer_single_trial():
+    dataset_key = CONFIG["DATASET_ID_MAP"][1]
+    X, y = load_dataset(dataset_key)
+    opt = BattleTestedOptimizer(dataset_num=1, max_trials=1)
+    results = opt.run_optimization(X, y)
+    assert "test_r2" in results

--- a/utils.py
+++ b/utils.py
@@ -321,21 +321,37 @@ def print_results_summary(results: dict, dataset_num: int):
                 print(f"📈 {Colors.BLUE}Room for improvement{Colors.END}")
 
 
-def validate_dataset_files(dataset_id: int):
+def validate_dataset_files(dataset_name: str):
+    """Validate that a dataset is available for loading.
+
+    Parameters
+    ----------
+    dataset_name : str
+        Name of the dataset as defined in ``CONFIG['SKLEARN_DATASETS']``.
+
+    Returns
+    -------
+    bool
+        ``True`` if the dataset configuration exists and any associated files
+        (for external datasets) are present.
     """
-    Validate that dataset files exist.
-    
-    Args:
-        dataset_id: Dataset identifier
-        
-    Returns:
-        bool: True if files exist, False otherwise
-    """
-    if dataset_id not in CONFIG["SKLEARN_DATASETS"]:
+    if dataset_name not in CONFIG["SKLEARN_DATASETS"]:
         return False
-    
-    dataset_info = CONFIG["SKLEARN_DATASETS"][dataset_id]
+
+    dataset_info = CONFIG["SKLEARN_DATASETS"][dataset_name]
+
+    # When using scikit-learn built-in datasets there are no external files to
+    # validate. The keys ``predictors`` and ``targets`` are optional and may be
+    # ``None`` for built-in datasets.
+    predictor_file = dataset_info.get("predictors")
+    target_file = dataset_info.get("targets")
+
     predictor_exists = True
     target_exists = True
-    
-    return predictor_exists and target_exists 
+
+    if predictor_file:
+        predictor_exists = Path(predictor_file).exists()
+    if target_file:
+        target_exists = Path(target_file).exists()
+
+    return predictor_exists and target_exists


### PR DESCRIPTION
## Summary
- add dataset mapping in config
- update dataset validation to use names instead of ids
- adjust main entry point to reference dataset mapping
- ensure package `__init__` can be imported when run as script
- add basic unit tests for dataset loading and optimizers

## Testing
- `pytest -q`
- `python main.py --dataset 1 --optimizer systematic --trials 1`
- `python main.py --dataset 2 --optimizer systematic --trials 1`
- `python main.py --dataset 3 --optimizer systematic --trials 1`


------
https://chatgpt.com/codex/tasks/task_b_684f2dac23e08330a988fce1c966095a