### PR TITLE
Add multiple dataset loaders

### DIFF
--- a/config.py
+++ b/config.py
@@ -39,6 +39,15 @@ CONFIG = {
         "california_housing": {"loader": "fetch_california_housing", "type": "regression", "name": "California Housing"},
         "wine": {"loader": "load_wine", "type": "classification", "name": "Wine"},
         "breast_cancer": {"loader": "load_breast_cancer", "type": "classification", "name": "Breast Cancer Wisconsin"},
+        "diabetes_frame": {"loader": "load_diabetes", "type": "regression", "name": "Diabetes (as_frame=True)"},
+        "synthetic_regression": {"loader": "make_regression", "type": "regression", "name": "Synthetic Regression"},
+        "airfoil_self_noise": {"loader": "fetch_openml", "type": "regression", "name": "Airfoil Self Noise"},
+        "friedman1_small": {"loader": "make_friedman1", "type": "regression", "name": "Friedman1 Small"},
+        "friedman2": {"loader": "make_friedman2", "type": "regression", "name": "Friedman2"},
+        "friedman3": {"loader": "make_friedman3", "type": "regression", "name": "Friedman3"},
+        "california_housing_frame": {"loader": "fetch_california_housing", "type": "regression", "name": "California Housing (as_frame=True)"},
+        "energy_efficiency": {"loader": "fetch_openml", "type": "regression", "name": "Energy Efficiency"},
+        "openml_42092": {"loader": "fetch_openml", "type": "regression", "name": "OpenML Dataset 42092"},
     },
     
     # Optuna optimization parameters

--- a/main.py
+++ b/main.py
@@ -16,8 +16,13 @@ from optimizer import SystematicOptimizer, BattleTestedOptimizer
 def main():
     """Main entry point for auto_optuna package."""
     parser = argparse.ArgumentParser(description='Auto Optuna ML Optimization')
-    parser.add_argument('--dataset', type=int, default=1, choices=[1, 2, 3],
-                       help='Dataset to use (1=Hold-1, 2=Hold-2, 3=Hold-1 Full)')
+    parser.add_argument(
+        '--dataset',
+        type=int,
+        default=1,
+        choices=list(DATASET_FILES.keys()),
+        help='Dataset ID to use'
+    )
     parser.add_argument('--optimizer', type=str, default='systematic', 
                        choices=['systematic', 'battle_tested'],
                        help='Optimizer type to use')


### PR DESCRIPTION
## Summary
- expand available dataset entries in `DATASET_FILES`
- generalize `load_dataset` to handle arbitrary loader params
- import `fetch_openml` and pandas support
- expose all dataset IDs via CLI
- register datasets in config

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68505e2097348330ae1a061f1f408179