### PR TITLE
Add additional preprocessing components

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -13,9 +13,15 @@ Main Components:
 from .optimizer import SystematicOptimizer, BattleTestedOptimizer
 from .transformers import (
     KMeansOutlierTransformer,
-    IsolationForestTransformer, 
-    LocalOutlierFactorTransformer
+    IsolationForestTransformer,
+    LocalOutlierFactorTransformer,
+    OutlierFilterTransformer,
+    HSICFeatureSelector,
 )
+from sklearn.preprocessing import QuantileTransformer, PowerTransformer, MinMaxScaler
+from sklearn.feature_selection import RFECV
+from sklearn.decomposition import KernelPCA, TruncatedSVD
+from sklearn.compose import TransformedTargetRegressor
 from .config import CONFIG, Colors
 from .utils import load_dataset, setup_logging, console, HAS_RICH, Tree
 
@@ -26,6 +32,15 @@ __all__ = [
     "KMeansOutlierTransformer",
     "IsolationForestTransformer",
     "LocalOutlierFactorTransformer",
+    "OutlierFilterTransformer",
+    "HSICFeatureSelector",
+    "QuantileTransformer",
+    "PowerTransformer",
+    "MinMaxScaler",
+    "RFECV",
+    "KernelPCA",
+    "TruncatedSVD",
+    "TransformedTargetRegressor",
     "CONFIG",
     "Colors",
     "load_dataset",

--- a/transformers.py
+++ b/transformers.py
@@ -9,6 +9,7 @@ from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.cluster import KMeans
 from sklearn.ensemble import IsolationForest
 from sklearn.neighbors import LocalOutlierFactor
+from sklearn.metrics.pairwise import pairwise_kernels
 
 class KMeansOutlierTransformer(BaseEstimator, TransformerMixin):
     """Remove outliers via K-means clustering"""
@@ -41,6 +42,72 @@ class KMeansOutlierTransformer(BaseEstimator, TransformerMixin):
     
     def get_support_mask(self):
         return self.mask_
+
+
+class OutlierFilterTransformer(BaseEstimator, TransformerMixin):
+    """Filter out clusters smaller than a minimum size ratio."""
+
+    def __init__(self, n_clusters=3, min_cluster_size_ratio=0.1, remove=True):
+        self.n_clusters = n_clusters
+        self.min_cluster_size_ratio = min_cluster_size_ratio
+        self.remove = remove
+        self.kmeans = None
+        self.valid_clusters_ = None
+        self.outlier_indices_ = None
+
+    def fit(self, X, y=None):
+        del y  # Not used
+        self.kmeans = KMeans(n_clusters=self.n_clusters, random_state=42, n_init=10)
+        labels = self.kmeans.fit_predict(X)
+        counts = np.bincount(labels)
+        min_size = int(len(X) * self.min_cluster_size_ratio)
+        self.valid_clusters_ = np.where(counts >= min_size)[0]
+        mask = np.isin(labels, self.valid_clusters_)
+        self.outlier_indices_ = np.where(~mask)[0]
+        self.mask_ = mask
+        return self
+
+    def transform(self, X):
+        labels = self.kmeans.predict(X)
+        mask = np.isin(labels, self.valid_clusters_)
+        if self.remove:
+            return X[mask]
+        return X
+
+    def get_support_mask(self):
+        return self.mask_
+
+
+class HSICFeatureSelector(BaseEstimator, TransformerMixin):
+    """Select top-k features using a simplified HSIC criterion."""
+
+    def __init__(self, k=10, gamma=1.0):
+        self.k = k
+        self.gamma = gamma
+        self.selected_features_ = None
+        self.scores_ = None
+
+    def _compute_hsic(self, X, y):
+        n = X.shape[0]
+        H = np.eye(n) - np.ones((n, n)) / n
+        Ky = pairwise_kernels(y.reshape(-1, 1), metric="rbf", gamma=self.gamma)
+        scores = []
+        for i in range(X.shape[1]):
+            Kx = pairwise_kernels(X[:, i].reshape(-1, 1), metric="rbf", gamma=self.gamma)
+            hsic = np.trace(Kx @ H @ Ky @ H) / (n - 1) ** 2
+            scores.append(hsic)
+        return np.array(scores)
+
+    def fit(self, X, y):
+        X = np.asarray(X)
+        y = np.asarray(y)
+        self.scores_ = self._compute_hsic(X, y)
+        idx = np.argsort(self.scores_)[::-1]
+        self.selected_features_ = idx[: self.k]
+        return self
+
+    def transform(self, X):
+        return X[:, self.selected_features_]
 
 
 class IsolationForestTransformer(BaseEstimator, TransformerMixin):


### PR DESCRIPTION
## Summary
- expose more transformers and feature selectors in package init
- implement `OutlierFilterTransformer` and `HSICFeatureSelector`

## Testing
- `python -m py_compile *.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68505ec1fb608330abf081c79c3b5e8d