### PR TITLE
Add CI with Arch Linux and requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+jobs:
+  ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: pytest -q
+
+  arch:
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install system packages
+        run: pacman -Sy --noconfirm python python-pip git
+      - name: Install dependencies
+        run: |
+          pip install --no-cache-dir -r requirements.txt
+      - name: Run tests
+        run: pytest -q

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+optuna
+numpy
+pandas
+matplotlib
+seaborn
+scikit-learn
+joblib
+pytest
+rich


### PR DESCRIPTION
## Summary
- add Python CI workflow running on Ubuntu and Arch Linux container
- list core dependencies in `requirements.txt`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6850866729648330ba7666acef14de0d