### PR TITLE
Show baseline plot for all R2 values

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -379,7 +379,7 @@ def create_diagnostic_plots(y_true, y_pred, study=None, dataset_num: int = 1,
             if noise_ceiling:
                 ax3.axhline(y=noise_ceiling, color='orange', linestyle=':', 
                            label=f'Noise Ceiling = {noise_ceiling:.3f}')
-            if baseline_r2:
+            if baseline_r2 is not None:
                 ax3.axhline(y=baseline_r2, color='red', linestyle='--',
                            label=f'Baseline = {baseline_r2:.3f}')
             ax3.set_xlabel('Trial Number')


### PR DESCRIPTION
## Summary
- update diagnostic plots to display baseline line even when R² is zero or negative

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6854a7a97df883338cf01b8d6e1c3e6a