### PR TITLE
Add invalid dataset load test

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -32,3 +32,9 @@ def test_battle_tested_optimizer_single_trial():
     opt = BattleTestedOptimizer(dataset_num=1, max_trials=1)
     results = opt.run_optimization(X, y)
     assert "test_r2" in results
+
+
+def test_load_dataset_invalid_id():
+    """Ensure invalid dataset identifiers raise a ValueError."""
+    with pytest.raises(ValueError):
+        load_dataset(999)


### PR DESCRIPTION
## Summary
- test that loading an unknown dataset raises `ValueError`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6854a7ba822483339a12090f33c9b3ad